### PR TITLE
編集：ESlint。react-cookieで使われていない定数がある場合、ESlintで警告されないようにルールを追加

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -8,5 +8,7 @@ module.exports = {
     sourceType: 'module',
     ecmaFeatures: { jsx: true },
   },
-  rules: {},
+  rules: {
+    'no-unused-vars': ['error', { varsIgnorePattern: '^_' }], // react-cookieで使わない定数を許容するために追加。
+  },
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,7 +10,7 @@ export const Header = () => {
   const auth = useSelector((state) => state.auth.isSignIn)
   const dispatch = useDispatch()
   const navigation = useNavigate()
-  const [removeCookie] = useCookies()
+  const [_cookies, _setCookie, removeCookie] = useCookies()
   const handleSignOut = () => {
     dispatch(signOut())
     removeCookie('token')

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -15,7 +15,7 @@ export const SignIn = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [errorMessage, setErrorMessage] = useState()
-  const [setCookie] = useCookies()
+  const [_cookies, setCookie, _removeCookie] = useCookies()
   const handleEmailChange = (e) => setEmail(e.target.value)
   const handlePasswordChange = (e) => setPassword(e.target.value)
   const onSignIn = () => {

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -16,7 +16,7 @@ export const SignUp = () => {
   const [name, setName] = useState('')
   const [password, setPassword] = useState('')
   const [errorMessage, setErrorMessge] = useState()
-  const [setCookie] = useCookies()
+  const [_cookies, setCookie, _removeCookie] = useCookies()
   const handleEmailChange = (e) => setEmail(e.target.value)
   const handleNameChange = (e) => setName(e.target.value)
   const handlePasswordChange = (e) => setPassword(e.target.value)


### PR DESCRIPTION
## 問題

useCookiesで宣言されているが使用されていない変数があった。そのためESLintから警告が表示された。
ESLintの警告を解決するため使用されていない変数を消した。その後アプリのログインが失敗するようになった。

## 原因

使用されていない変数の削除により、Cookieに関する処理を担当していた変数が削除されてしまったため、Cookieの設定ができなくなり、アプリのログインが失敗するようになった。

## 結論

ESLintにルールを追記した。未使用の変数の先頭に _ をつけることで、警告を回避するようにした。
今回の場合useCookiesで警告が出る変数の先頭に _ をつけた。